### PR TITLE
Define User and Message models in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,31 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id           Int       @id @default(autoincrement())
+  username     String    @unique
+  email        String    @unique
+  passwordHash String    @map("password_hash")
+  messages     Message[] @relation("UserMessages")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  @@map("users")
+}
+
+model Message {
+  id        Int      @id @default(autoincrement())
+  content   String
+  senderId  Int      @map("sender_id")
+  sender    User     @relation("UserMessages", fields: [senderId], references: [id])
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([senderId])
+  @@map("messages")
+}


### PR DESCRIPTION
## Summary
- create `prisma/schema.prisma`
- add datasource and generator blocks
- define `User` and `Message` models with relations

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68725674bb848321b7dfdca383d6df9b