### PR TITLE
Add reusable auth and role guards

### DIFF
--- a/src/shared/decorators/roles.decorator.ts
+++ b/src/shared/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/shared/guards/jwt-auth.guard.ts
+++ b/src/shared/guards/jwt-auth.guard.ts
@@ -1,0 +1,17 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { JwtPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(err: unknown, user: JwtPayload, info: unknown, context: ExecutionContext) {
+    if (err || !user) {
+      throw err || new UnauthorizedException();
+    }
+    const req = context.switchToHttp().getRequest();
+    if (req) {
+      req.user = user;
+    }
+    return user;
+  }
+}

--- a/src/shared/guards/jwt-payload.interface.ts
+++ b/src/shared/guards/jwt-payload.interface.ts
@@ -1,0 +1,6 @@
+export interface JwtPayload {
+  userId: string;
+  email: string;
+  username: string;
+  role?: string;
+}

--- a/src/shared/guards/roles.guard.ts
+++ b/src/shared/guards/roles.guard.ts
@@ -1,9 +1,44 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { JwtPayload } from './jwt-payload.interface';
+import { Socket } from 'socket.io';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    // HTTP request
+    if (context.getType<string>() === 'http') {
+      const request = context.switchToHttp().getRequest();
+      const user = (request.user as JwtPayload & { role?: string }) || null;
+      if (!user) {
+        throw new UnauthorizedException();
+      }
+      if (!requiredRoles.includes((user as any).role)) {
+        throw new ForbiddenException();
+      }
+      return true;
+    }
+
+    // WebSocket
+    const client: Socket = context.switchToWs().getClient();
+    const user = (client.data.user as JwtPayload & { role?: string }) || null;
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    if (!requiredRoles.includes((user as any).role)) {
+      throw new ForbiddenException();
+    }
     return true;
   }
 }
-

--- a/src/shared/guards/ws-jwt-auth.guard.ts
+++ b/src/shared/guards/ws-jwt-auth.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Socket } from 'socket.io';
+import { JwtPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class WsJwtAuthGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client: Socket = context.switchToWs().getClient();
+    const authHeader = client.handshake?.headers?.authorization;
+    if (!authHeader) {
+      throw new UnauthorizedException('Missing auth token');
+    }
+    const [, token] = authHeader.split(' ');
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      client.data.user = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create shared `JwtAuthGuard` for HTTP
- create WebSocket `WsJwtAuthGuard`
- add `Roles` decorator for route metadata
- implement `RolesGuard` for RBAC
- define `JwtPayload` interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873517c986483218afad18094317df8