### PR TITLE
Set up config module with env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+PORT=3000
+DATABASE_URL=postgresql://user:password@localhost:5432/chatapp
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRATION=3600s
+REFRESH_TOKEN_EXPIRATION=7d

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,5 +1,11 @@
 export default () => ({
   port: parseInt(process.env.PORT || '3000', 10),
-  jwtSecret: process.env.JWT_SECRET || 'secret',
-  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '3600s',
+  database: {
+    url: process.env.DATABASE_URL,
+  },
+  jwt: {
+    secret: process.env.JWT_SECRET,
+    accessTokenTtl: process.env.JWT_EXPIRATION,
+    refreshTokenTtl: process.env.REFRESH_TOKEN_EXPIRATION,
+  },
 });

--- a/src/modules/auth/infrastructure/jwt/jwt.module.ts
+++ b/src/modules/auth/infrastructure/jwt/jwt.module.ts
@@ -8,8 +8,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => ({
-        secret: config.get<string>('jwtSecret'),
-        signOptions: { expiresIn: config.get<string>('jwtExpiresIn') },
+        secret: config.get<string>('jwt.secret'),
+        signOptions: { expiresIn: config.get<string>('jwt.accessTokenTtl') },
       }),
     }),
   ],

--- a/src/modules/auth/infrastructure/strategies/jwt.strategy.ts
+++ b/src/modules/auth/infrastructure/strategies/jwt.strategy.ts
@@ -15,7 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>('jwtSecret'),
+      secretOrKey: configService.get<string>('jwt.secret'),
     });
   }
 


### PR DESCRIPTION
## Summary
- centralize configuration settings
- wire Jwt services to new config keys
- add example environment variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873538099248321947bd27b105781ea